### PR TITLE
Allow for custom headers to be used

### DIFF
--- a/src/castle.py
+++ b/src/castle.py
@@ -28,7 +28,7 @@ class CASTLE():
         self.callback: Callable[[pd.Series], None] = callback
 
         self.deque: Deque = deque()
-        self.headers: List[str] = headers[1:]
+        self.headers: List[str] = headers
 
         # Required number of tuples for a cluster to be complete
         self.k: int = k

--- a/src/main.py
+++ b/src/main.py
@@ -38,7 +38,7 @@ def main():
 
     frame = pd.read_csv(args.filename).sample(20)
 
-    headers = list(frame.columns.values)
+    headers = ["PickupLocationID", "TripDistance"]
     stream = CASTLE(handler, headers, args.k, args.delta, args.beta)
 
     for (_, row) in frame.iterrows():


### PR DESCRIPTION
Allow for the user to easily specify the headers to anonymise and stop cutting
out some of the headers.