### PR TITLE
Change CASTLE() to take a Parameters class

### DIFF
--- a/src/castle.py
+++ b/src/castle.py
@@ -4,17 +4,25 @@ import pandas as pd
 
 from typing import Any, Callable, Deque, Dict, List, Optional
 from collections import deque
+from dataclasses import dataclass
 
 from cluster import Cluster
 from range import Range
 from item import Item
+
+@dataclass
+class Parameters:
+    k: int
+    delta: int
+    beta: int
+    mu: int
 
 class CASTLE():
 
     """An implementation of the CASTLE Algorithm designed by Jianneng Cao,
     Barbara Carminati, Elena Ferrari and Kian-Lee Tan."""
 
-    def __init__(self, callback: Callable[[pd.Series], None], headers: List[str], k: int, delta: int, beta: int, mu: int):
+    def __init__(self, callback: Callable[[pd.Series], None], headers: List[str], params: Parameters):
         """Initialises the CASTLE algorithm with necessary parameters.
 
         Args:
@@ -31,16 +39,16 @@ class CASTLE():
         self.headers: List[str] = headers
 
         # Required number of tuples for a cluster to be complete
-        self.k: int = k
+        self.k: int = params.k
         # Maximum number of active tuples
-        self.delta: int = delta
+        self.delta: int = params.delta
         # Maximum number of clusters that can be active
-        self.beta: int = beta
+        self.beta: int = params.beta
         # Maximum amount of information loss, by default set to infinity as we
         # have no clusters
         self.tau: float = math.inf
         # Number of values to use in the rolling average
-        self.mu: int = mu
+        self.mu: int = params.mu
 
         # Set of non-ks anonymised clusters
         self.big_gamma: List[Cluster] = []

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ import matplotlib.patches as patches
 
 import app
 
-from castle import CASTLE
+from castle import CASTLE, Parameters
 from range import Range
 
 def handler(value: pd.Series):
@@ -39,7 +39,8 @@ def main():
     frame = pd.read_csv(args.filename).sample(20)
 
     headers = ["PickupLocationID", "TripDistance"]
-    stream = CASTLE(handler, headers, args.k, args.delta, args.beta, args.mu)
+    params = Parameters(args.k, args.delta, args.beta, args.mu)
+    stream = CASTLE(handler, headers, params)
 
     for (_, row) in frame.iterrows():
         stream.insert(row)


### PR DESCRIPTION
Change the CASTLE constructor to take a dataclass of Parameters. This is an
autogenerated class that behaves like a regular struct. This reduces the number
of arguments that CASTLE needs to take and cleans up the constructor a little.