### PR TITLE
Add optional seed and sample size arguments

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -42,6 +42,20 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
+        "--seed",
+        type=int,
+        help="The random seed to use for the simulation"
+    )
+
+    parser.add_argument(
+        "--sample-size",
+        nargs="?",
+        default=20,
+        type=int,
+        help="The number of samples to use for the simulation"
+    )
+
+    parser.add_argument(
         "-f", "--filename",
         nargs="?",
         default="data.csv",

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 import time
 
+import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import matplotlib.patches as patches
@@ -35,8 +36,13 @@ def display_visualisation(stream: CASTLE):
 
 def main():
     args = app.parse_args()
+    print("args: {}".format(args))
 
-    frame = pd.read_csv(args.filename).sample(20)
+    seed = args.seed if args.seed else np.random.randint(1e6)
+    np.random.seed(seed)
+    print("USING RANDOM SEED: {}".format(seed))
+
+    frame = pd.read_csv(args.filename).sample(args.sample_size)
 
     headers = ["PickupLocationID", "TripDistance"]
     params = Parameters(args.k, args.delta, args.beta, args.mu)


### PR DESCRIPTION
Add optional arguments to the CLI for specifying a seed and sample size to the
simulation. This allows for easier debugging, as not all runs produce a crash.
The simulation will display the seed when it picks it, and running with --seed
SEED will allow the simulation to be re-run exactly.

For example, running with --seed 100 currently will cause a crash, but --seed
101 will not. Reproduceability is important for figuring out why certain things
work and others do not.