### PR TITLE
Fix the 'tuple not in deque' error when outputting

### DIFF
--- a/src/castle.py
+++ b/src/castle.py
@@ -123,8 +123,8 @@ class CASTLE():
             for t in cluster.contents:
                 [generalised, original_tuple] = cluster.generalise(t)
                 print("OUTPUT")
+                self.suppress_tuple(original_tuple)
                 self.callback(generalised)
-                self.global_tuples.remove(original_tuple)
 
             # Calculate the information loss of the cluster
             info_loss = cluster.information_loss(self.global_ranges)
@@ -233,8 +233,8 @@ class CASTLE():
             # Pick a random cluster from the set and generalise, then output
             random_cluster = np.random.choice(KCset)
             generalised, original = random_cluster.generalise(t)
-            self.global_tuples.remove(original)
-            return self.callback(t)
+            self.suppress_tuple(original)
+            return self.callback(generalised)
 
         m = 0
 


### PR DESCRIPTION
Fix the 'tuple not in deque' error that sometimes occurs when outputting a
tuple. This was caused by a tuple not being removed from its parent cluster
when being output in this location. While it would be removed from the global
tuple queue, the cluster could then be later used as part of a merge operation.
This could move the tuple to another 'live' cluster, which could then be output
at a later date, thus outputting the tuple again and failing.

This also fixes the other case that could happen when we can output using a
cluster in `big_gamma`. This currently never happens as clusters are not moved
around correctly, but fixes it for the future.

Also enforce an ordering, where we should suppress a tuple and then output it.
This is because suppression should not take long, whereas `callback` is unknown
to us. Thus, suppressing removes the tuple as early as possible.