### PR TITLE
Ensure Items cannot be in multiple clusters

### DIFF
--- a/src/cluster.py
+++ b/src/cluster.py
@@ -28,6 +28,13 @@ class Cluster():
 
         """
         self.contents.append(element)
+
+        # Check whether the item is already in a cluster
+        if element.parent:
+            # If it is, remove it so that we do not reach an invalid state
+            element.parent.remove(element)
+
+        # Update the parent of the item to be this cluster
         element.parent = self
 
         for k, v in self.ranges.items():

--- a/src/test_cluster.py
+++ b/src/test_cluster.py
@@ -77,3 +77,27 @@ def test_out_of_bounds():
     }
 
     assert not c.within_bounds(t)
+
+def test_no_cluster_intersection():
+    headers = ["Age", "Salary"]
+
+    t = Item(
+        pd.Series(
+            data=np.array([25, 27]),
+            index=headers
+        ),
+        headers
+    )
+
+    c1 = Cluster(headers)
+    c2 = Cluster(headers)
+
+    c1.insert(t)
+
+    # Ensure only c1 contains an item
+    assert len(c1) == 1 and len(c2) == 0
+
+    c2.insert(t)
+
+    # Ensure t was removed from c1 after insertion
+    assert len(c1) == 0 and len(c2) == 1


### PR DESCRIPTION
Ensure Items cannot be contained within multiple clusters. Cluster.insert
implements a basic detector, checking that the inserted item does not have a
parent. If it does, it removes it from that cluster and then updates the parent
node. Add a test to ensure this is the case as well.