### PR TITLE
Fix a division by zero in Range.VInfoLoss

### DIFF
--- a/src/range.py
+++ b/src/range.py
@@ -38,7 +38,14 @@ class Range():
         Returns: VInfoLoss with respect to other
 
         """
-        return (self.upper - self.lower) / (other.upper - other.lower)
+        ds = self.upper - self.lower
+        do = other.upper - other.lower
+
+        # Deal with division by 0
+        if ds == 0 and do == 0:
+            return 0
+
+        return ds / do
 
     def within_bounds(self, value: float):
         """Checks whether the value is within the bounds of the range.

--- a/src/test_range.py
+++ b/src/test_range.py
@@ -19,6 +19,12 @@ def test_range_information_loss():
 
     assert r / I == 0.25
 
+def test_range_divide_by_zero():
+    r = Range(42, 42)
+    I = Range(42, 42)
+
+    assert r / I == 0
+
 def test_within_range():
     r = Range(5, 10)
     assert r.within_bounds(7)


### PR DESCRIPTION
Fix a division by zero error in VInfoLoss. This would occur when only one tuple
had been inserted into the algorithm, meaning that the global ranges would have
the same minimum and maximum value. Instead, simply return 0 in this case.