### PR TITLE
Update generalise to output a sample value as well

### DIFF
--- a/src/cluster.py
+++ b/src/cluster.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import numpy as np
 import pandas as pd
 
 from typing import Dict, List
@@ -19,6 +20,8 @@ class Cluster():
 
         for header in headers:
             self.ranges[header] = Range()
+
+        self.sample_values: Dict[str, float] = {}
 
     def insert(self, element: Item):
         """Inserts a tuple into the cluster
@@ -60,11 +63,23 @@ class Cluster():
 
         """
         gen_tuple = copy.deepcopy(t)
+
         for h, v in self.ranges.items():
             gen_tuple.data.loc['min' + h] = v.lower
+
+            # Pick a random person to use for this attribute
+            if not h in self.sample_values:
+                self.sample_values[h] = np.random.choice(self.contents)[h]
+
+            gen_tuple.data.loc['spc' + h] = self.sample_values[h]
+
             gen_tuple.data.loc['max' + h] = v.upper
+
+
             gen_tuple.headers.append('min' + h)
+            gen_tuple.headers.append('spc' + h)
             gen_tuple.headers.append('max' + h)
+
             gen_tuple.headers.remove(h)
             del gen_tuple.data[h]
 

--- a/src/test_cluster.py
+++ b/src/test_cluster.py
@@ -7,22 +7,50 @@ from range import Range
 
 def test_generalise():
 
-    frame = pd.read_csv("data.csv")
+    headers = ["Age", "Salary"]
 
-    t = Item(frame.iloc[0], headers=["PickupLocationID", "TripDistance"])
-    a = Item(frame.iloc[1], headers=["PickupLocationID", "TripDistance"])
-    b = Item(frame.iloc[2], headers=["PickupLocationID", "TripDistance"])
-    c = Cluster(headers=["PickupLocationID", "TripDistance"])
-    c.insert(t)
+    a = Item(
+        pd.Series(
+            data=np.array([25, 30]),
+            index=headers
+        ),
+        headers
+    )
+
+    b = Item(
+        pd.Series(
+            data=np.array([22, 27]),
+            index=headers
+        ),
+        headers
+    )
+
+    c = Cluster(headers)
+
     c.insert(a)
     c.insert(b)
 
-    t, orig = c.generalise(t)
-    d = {"pid":1, "minPickupLocationID":49, "maxPickupLocationID":264, "minTripDistance":.00, "maxTripDistance":0.86}
-    df = pd.Series(data=d)
-    test = Item(df ,headers=["minPickupLocationID", "maxPickupLocationID", "minTripDistance", "maxTripDistance"])
+    np.random.seed(42)
+    t = c.generalise(a)[0]
 
-    assert t == test
+    generalised_headers = [
+        "minAge", "spcAge", "maxAge",
+        "minSalary", "spcSalary", "maxSalary"
+    ]
+
+    expected = Item(
+        pd.Series(
+            data=np.array([22, 25, 25, 27, 27, 30]),
+            index=generalised_headers
+        ),
+        generalised_headers
+    )
+
+    assert t == expected
+
+    # We should get the same values a second time
+    t = c.generalise(b)[0]
+    assert t == expected
 
 def test_within_bounds_after_insert():
     headers = ["Age", "Salary"]


### PR DESCRIPTION
Update the generalise function for clusters to output a sample value from the
cluster for each attribute. A different sample tuple can be used for each
attribute. Fix the test to work for this case.