### PR TITLE
Fix split_l and generate_buckets

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -42,7 +42,7 @@ def main():
     np.random.seed(seed)
     print("USING RANDOM SEED: {}".format(seed))
 
-    frame = pd.read_csv(args.filename).sample(20)
+    frame = pd.read_csv(args.filename).sample(args.sample_size)
 
     headers = ["PickupLocationID", "TripDistance"]
     sensitive_attr = "FareAmount"


### PR DESCRIPTION
Fix the split_l function in CASTLE, along with generate_buckets, and return the
args.sample_size variable to its rightful place.

np.random.randint is non-inclusive unlike random.randint, so we need to remove
the -1.

When calculating the number of tuples to use, we should truncate it as it can
sometimes be a float. This is inline with what Alistair suggested.

Item objects cannot access the underlying data through a `.`, so `[attr]` must
be used instead, and Clusters do not allow for iteration, so this should be
C.contents.

generate_buckets needed a docstring, so I added one. It also was only making a
single bucket as there was only ever a single sensitive attribute, where it
should be making one for each value that the sensitive attribute has in the
data.

Return args.sample_size to where it should be instead of always using a
subsample of 20.