### PR TITLE
Calculate total_diversity correctly

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -44,7 +44,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--l",
         nargs="?",
-        default=5,
+        default=1,
         type=int,
         help="The value of l to use"
     )

--- a/src/castle.py
+++ b/src/castle.py
@@ -248,15 +248,13 @@ class CASTLE():
         if m > len(self.big_gamma) / 2:
             return self.suppress_tuple(t)
 
+        total_tuples = sum([len(cluster) for cluster in self.big_gamma])
         diversity_values = set()
 
         for cluster in self.big_gamma:
             diversity_values.update(cluster.diversity)
 
-        total_diversity = self.l < len(diversity_values)
-        total_cluster_size = sum([len(cluster) for cluster in self.big_gamma])
-
-        if total_cluster_size < self.k or not total_diversity:
+        if total_tuples < self.k or len(diversity_values) < self.l:
             return self.suppress_tuple(t)
 
         mc = self.merge_clusters(t.parent)


### PR DESCRIPTION
Alistair says that total_diversity should be the length of the union of all
current diversity sets. We should also use `or` when checking the boolean
instead of `and`.