### PR TITLE
Update total_tuples to length of a set

### DIFF
--- a/src/castle.py
+++ b/src/castle.py
@@ -335,7 +335,7 @@ class CASTLE():
         if m > len(self.big_gamma) / 2:
             return self.suppress_tuple(t)
 
-        total_tuples = sum([len(cluster) for cluster in self.big_gamma])
+        total_tuples = len({t['pid'] for t in self.global_tuples})
         diversity_values = set()
 
         for cluster in self.big_gamma:


### PR DESCRIPTION
Update the `total_tuples` variable in `delay_constraint` to be the length of
the set of all `pid` values, instead of the length of each cluster
individually. This is because otherwise we can reach `merge_clusters` without
enough unique `pid` values to satisfy the `k-anonymity` constraint, at which
point we will get a `min() arg is an empty sequence` error.