### PR TITLE
Add --history and cleanup main.py

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -68,26 +68,34 @@ def build_parser() -> argparse.ArgumentParser:
 
     parser.add_argument(
         "--display",
-        action="store_true"
+        action="store_true",
+        help="Whether or not to display a graph after execution"
     )
 
     parser.add_argument(
         "--disable-dp",
-        action="store_false"
+        action="store_false",
+        help="Whether or not to disable differential privacy"
     )
 
     parser.add_argument(
         "--phi",
         nargs="?",
         type=int,
-        help="phi value used to perturb tuples for k anonymity"
+        help="The phi value used to perturb tuples for differential privacy"
     )
 
     parser.add_argument(
         "--big-beta",
         nargs="?",
         type=float,
-        help="drop input tuples with probability 1 - beta"
+        help="Drop input tuples with probability 1 - beta"
+    )
+
+    parser.add_argument(
+        "--history",
+        action="store_true",
+        help="Whether or not to store a history of all inserted tuples"
     )
 
     return parser

--- a/src/castle.py
+++ b/src/castle.py
@@ -31,6 +31,7 @@ class Parameters():
         self.phi = 100 * np.log(2)
         self.dp = True
         self.big_beta = 1
+        self.history = False
 
         # If we have some arguments, try and use those instead
         if args:
@@ -42,6 +43,7 @@ class Parameters():
             self.phi = self.optional(args.phi, self.phi)
             self.dp = self.optional(args.disable_dp, self.dp)
             self.big_beta = self.optional(args.big_beta, self.big_beta)
+            self.history = self.optional(args.history, self.history)
             return
 
     def optional(self, value, default):
@@ -58,13 +60,11 @@ class Parameters():
 
     def __str__(self):
         """Returns a string representation of the object
-        Returns: TODO
+        Returns: A string representation of the internal values
 
         """
-        return "Parameters(k={}, delta={}, beta={}, mu={}, l={}, phi={}, dp={}, big_beta={})".format(
-            self.k, self.delta, self.beta, self.mu,
-            self.l, self.phi, self.dp, self.big_beta
-        )
+        params = ["{}={}".format(k, v) for k, v in self.__dict__.items()]
+        return "Parameters({})".format(", ".join(params))
 
 class CASTLE():
 
@@ -78,15 +78,15 @@ class CASTLE():
             callback: The function to call when a tuple is ejected
             headers: The columns that need to be anonymised according to the
             algorithm
-            k: The level of anonymity to provide
-            delta: The maximum number of active tuples at a time
-            beta: The maximum number of active clusters at a time
+            sensitive_attr: The column to use for l-diversity
+            params: The parameters to use for the algorithm
         """
+        # The callback function for output tuples
         self.callback: Callable[[pd.Series], None] = callback
 
-        self.history: List[Item] = []
-        self.deque: Deque = deque()
+        # The headers to use for k-anonymity
         self.headers: List[str] = headers
+        # The sensitive attribute for l-diversity
         self.sensitive_attr: str = sensitive_attr
 
         # Required number of tuples for a cluster to be complete
@@ -111,6 +111,13 @@ class CASTLE():
             self.phi: int = params.phi
             # The percentage chance of ignoring a tuple
             self.big_beta: float = params.big_beta
+
+        # Whether we want to store the previously entered tuples
+        self.history: bool = params.history
+
+        # Optionally store all the tuples we have seen
+        if self.history:
+            self.tuple_history: List[Item] = []
 
         # Set of non-ks anonymised clusters
         self.big_gamma: List[Cluster] = []
@@ -220,7 +227,10 @@ class CASTLE():
             for t in [c for c in cluster.contents]:
                 [generalised, original_tuple] = cluster.generalise(t)
                 self.callback(generalised)
-                self.history.append(original_tuple)
+
+                if self.history:
+                    self.tuple_history.append(original_tuple)
+
                 output_pids.add(t['pid'])
                 output_diversity.add(t.sensitive_attr)
                 self.suppress_tuple(original_tuple)
@@ -333,7 +343,10 @@ class CASTLE():
             random_cluster = np.random.choice(KCset)
             generalised, original = random_cluster.generalise(t)
             self.suppress_tuple(original)
-            self.history.append(original)
+
+            if self.history:
+                self.tuple_history.append(original)
+
             return self.callback(generalised)
 
         m = 0

--- a/src/main.py
+++ b/src/main.py
@@ -1,61 +1,13 @@
-import time
-
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
-import matplotlib.patches as patches
 
 import app
 
 from castle import CASTLE, Parameters
-from range import Range
+from visualisations import display_visualisation
 
 def handler(value: pd.Series):
     print("RECIEVED VALUE: \n{}".format(value))
-
-def create_rectangle(rx: Range, ry: Range) -> patches.Rectangle:
-    width = rx.upper - rx.lower
-    height = ry.upper - ry.lower
-    return patches.Rectangle((rx.lower, ry.lower), width, height, fill=False)
-
-def display_visualisation(stream: CASTLE):
-
-    cm = plt.cm.get_cmap('viridis')
-
-    ax = plt.subplot(1, 2, 1)
-    plt.title("CASTLE Ω Clusters and Output Tuples (Φ = {}, β = {})".format(stream.phi, stream.big_beta))
-    plt.xlabel("Pickup Location ID")
-    plt.ylabel("Trip Distance")
-
-    for cluster in stream.big_gamma:
-        plid_range = cluster.ranges["PickupLocationID"]
-        distance_range = cluster.ranges["TripDistance"]
-        ax.add_patch(create_rectangle(plid_range, distance_range))
-
-    pickup_id = [t["PickupLocationID"] for t in stream.global_tuples]
-    distance = [t["TripDistance"] for t in stream.global_tuples]
-    fare_amount = [t.sensitive_attr for t in stream.global_tuples]
-    s = plt.scatter(pickup_id, distance, c=fare_amount, cmap=cm)
-    plt.colorbar(s)
-
-    ax = plt.subplot(1, 2, 2)
-    plt.title("CASTLE Ω Clusters and Output Tuples (Φ = {}, β = {})".format(stream.phi, stream.big_beta))
-    plt.xlabel("Pickup Location ID")
-    plt.ylabel("Trip Distance")
-
-
-    for cluster in stream.big_omega:
-        plid_range = cluster.ranges["PickupLocationID"]
-        distance_range = cluster.ranges["TripDistance"]
-
-        ax.add_patch(create_rectangle(plid_range, distance_range))
-
-    pickup_id = [t["PickupLocationID"] for t in stream.history]
-    distance = [t["TripDistance"] for t in stream.history]
-    fare_amount = [t.sensitive_attr for t in stream.history]
-    s = plt.scatter(pickup_id, distance, c=fare_amount, cmap=cm)
-    plt.colorbar(s)
-    plt.show()
 
 def main():
     args = app.parse_args()

--- a/src/visualisations.py
+++ b/src/visualisations.py
@@ -1,0 +1,67 @@
+import matplotlib.pyplot as plt
+import matplotlib.patches as patches
+
+from castle import CASTLE
+from range import Range
+
+def create_rectangle(rx: Range, ry: Range) -> patches.Rectangle:
+    """Creates a rectangle for the ranges given
+
+    Args:
+        rx: The range for the x-axis
+        ry: The range for the y-axis
+
+    Returns: A patches.Rectangle object defining the rectangle
+
+    """
+    width = rx.upper - rx.lower
+    height = ry.upper - ry.lower
+    return patches.Rectangle((rx.lower, ry.lower), width, height, fill=False)
+
+def display_visualisation(stream: CASTLE):
+    """Displays the internal and external state of CASTLE
+
+    Args:
+        stream: An instance of CASTLE after finishing insertions
+
+    """
+    cm = plt.cm.get_cmap('viridis')
+    ax = plt.subplot(1, 2, 1) if stream.history else plt.subplot(1, 1, 1)
+
+    xlabel, ylabel = stream.headers
+
+    plt.title("CASTLE Ω Clusters and Output Tuples (Φ = {}, β = {})".format(stream.phi, stream.big_beta))
+    plt.xlabel(xlabel)
+    plt.ylabel(ylabel)
+
+    for cluster in stream.big_gamma:
+        plid_range = cluster.ranges[xlabel]
+        distance_range = cluster.ranges[ylabel]
+        ax.add_patch(create_rectangle(plid_range, distance_range))
+
+    pickup_id = [t[xlabel] for t in stream.global_tuples]
+    distance = [t[ylabel] for t in stream.global_tuples]
+    fare_amount = [t.sensitive_attr for t in stream.global_tuples]
+    s = plt.scatter(pickup_id, distance, c=fare_amount, cmap=cm)
+    plt.colorbar(s)
+
+    if stream.history:
+        ax = plt.subplot(1, 2, 2)
+        plt.title("CASTLE Ω Clusters and Output Tuples (Φ = {}, β = {})".format(stream.phi, stream.big_beta))
+        plt.xlabel(xlabel)
+        plt.ylabel(ylabel)
+
+        for cluster in stream.big_omega:
+            plid_range = cluster.ranges[xlabel]
+            distance_range = cluster.ranges[ylabel]
+
+            ax.add_patch(create_rectangle(plid_range, distance_range))
+
+        pickup_id = [t[xlabel] for t in stream.tuple_history]
+        distance = [t[ylabel] for t in stream.tuple_history]
+        fare_amount = [t.sensitive_attr for t in stream.tuple_history]
+        s = plt.scatter(pickup_id, distance, c=fare_amount, cmap=cm)
+        plt.colorbar(s)
+
+    plt.show()
+


### PR DESCRIPTION
Add the `--history` argument for storing the history of all tuples that are
inserted into CASTLE.

Add more documentation to the CLI.

Add more documentation to the __init__ function for CASTLE.

Move the visualisation code to `src/visualisations.py` to cleanup
`src/main.py`.